### PR TITLE
MNT move repo to univieCUBE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 [![Linux/MacOS builds on Travis](
-  https://travis-ci.com/VarIr/deepnog.svg?token=Pv7ns6A7X34baaBVUTz8&branch=master)](
-  https://travis-ci.com/VarIr/deepnog)
+  https://travis-ci.com/univieCUBE/deepnog.svg?branch=master)](
+  https://travis-ci.com/univieCUBE/deepnog)
 [![Windows builds on AppVeyor](
-  https://ci.appveyor.com/api/projects/status/g3h5ocwb51ygxylf/branch/master?svg=true)](
+  https://ci.appveyor.com/api/projects/status/ccdysyv0o2gey6iu/branch/master?svg=true)](
   https://ci.appveyor.com/project/VarIr/deepnog/branch/master)
 [![codecov](
-  https://codecov.io/gh/VarIr/deepnog/branch/master/graph/badge.svg?token=aP6UBdQDmk)](
-  https://codecov.io/gh/VarIr/deepnog)
+  https://codecov.io/gh/univieCUBE/deepnog/branch/master/graph/badge.svg)](
+  https://codecov.io/gh/univieCUBE/deepnog)
 [![Language grade: Python](
-  https://img.shields.io/lgtm/grade/python/g/VarIr/deepnog.svg?logo=lgtm&logoWidth=18)](
-  https://lgtm.com/projects/g/VarIr/deepnog/context:python)
+  https://img.shields.io/lgtm/grade/python/g/univieCUBE/deepnog.svg?logo=lgtm&logoWidth=18)](
+  https://lgtm.com/projects/g/univieCUBE/deepnog/context:python)
 [![Documentation Status](
   https://readthedocs.org/projects/deepnog/badge/?version=latest)](
   https://deepnog.readthedocs.io/en/latest/?badge=latest)

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -25,10 +25,10 @@
 
 ### Maintenance
 - Continuous integration on
-  - [Travis](https://travis-ci.com/VarIr/deepnog/) (Linux, MacOS)
+  - [Travis](https://travis-ci.com/univieCUBE/deepnog/) (Linux, MacOS)
   - [AppVeyor](https://ci.appveyor.com/project/VarIr/deepnog) (Windows)
-- [Codecov](https://codecov.io/gh/VarIr/deepnog/) coverage reports
-- [LGTM](https://lgtm.com/projects/g/VarIr/deepnog) code quality/security reports
+- [Codecov](https://codecov.io/gh/univieCUBE/deepnog/) coverage reports
+- [LGTM](https://lgtm.com/projects/g/univieCUBE/deepnog) code quality/security reports
 - Documentation on [ReadTheDocs](https://deepnog.readthedocs.io)
 - Upload to [PyPI](https://pypi.org/project/deepnog/), thus enabling
   `$ pip install deepnog`.
@@ -44,8 +44,8 @@ It already contains the following features:
 - CPU and GPU support
 - Runs on all major platforms (Linux, MacOS, Windows)
 
-[Next release]: https://github.com/VarIr/deepnog/compare/v1.1.0...HEAD
-[1.1.0]: https://github.com/VarIr/deepnog/releases/tag/v1.1.0
-[1.0.0]: https://github.com/VarIr/deepnog/releases/tag/v1.0.0final
+[Next release]: https://github.com/univieCUBE/deepnog/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/univieCUBE/deepnog/releases/tag/v1.1.0
+[1.0.0]: https://github.com/univieCUBE/deepnog/releases/tag/v1.0.0final
 
 [//]: # "Sections: Added, Fixed, Changed, Removed"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -87,7 +87,7 @@ autosummary_generate = True
 from doc.github_link import make_linkcode_resolve  # noqa
 
 linkcode_resolve = make_linkcode_resolve('deepnog',
-                                         'https://github.com/VarIr/'
+                                         'https://github.com/univieCUBE/'
                                          'deepnog/blob/{revision}/'
                                          '{package}/{path}#L{lineno}')
 

--- a/doc/development/contributing.rst
+++ b/doc/development/contributing.rst
@@ -14,7 +14,7 @@ Even small contributions improve the software's quality.
 
 Even if you are not familiar with programming languages and tools,
 you may contribute by filing bugs or any problems as a
-`GitHub issue <https://github.com/VarIr/deepnog/issues>`_.
+`GitHub issue <https://github.com/univieCUBE/deepnog/issues>`_.
 
 
 Git and branching model
@@ -38,19 +38,19 @@ Workflow
 
 In case of large changes to the software, please first get in contact
 with the authors for coordination, for example by filing an
-`issue <https://github.com/VarIr/deepnog/issues>`_.
+`issue <https://github.com/univieCUBE/deepnog/issues>`_.
 If you want to fix small issues (typos in the docs, obvious errors, etc.)
 you can - of course - directly submit a pull request (PR).
 
 #. Create a fork of `deepnog` in your GitHub account.
-    Simply click "Fork" button on `<https://github.com/VarIr/deepnog>`_.
+    Simply click "Fork" button on `<https://github.com/univieCUBE/deepnog>`_.
 
 
 #. Clone your fork on your computer.
     $ ``git clone git@github.com:YOUR-ACCOUNT-GOES-HERE/deepnog.git && cd deepnog``
 
 #. Add remote upstream.
-    $ ``git remote add upstream git@github.com:VarIr/deepnog.git``
+    $ ``git remote add upstream git@github.com:univieCUBE/deepnog.git``
 
 #. Create feature/bugfix branch.
     $ ``git checkout -b bugfix123 master``

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -37,7 +37,7 @@ You can always grab the latest version of ``deepnog`` directly from GitHub:
 .. code-block:: bash
 
    cd install_dir
-   git clone git@github.com:VarIr/deepnog.git
+   git clone git@github.com:univieCUBE/deepnog.git
    cd deepnog
    pip install -e .
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -32,7 +32,7 @@ with deep networks.
    :caption: Development
 
    Contributing <development/contributing>
-   Github Repository <https://github.com/VarIr/deepnog>
+   Github Repository <https://github.com/univieCUBE/deepnog>
    What's new (Changelog) <changelog.md>
 
 
@@ -70,7 +70,7 @@ to this free open source software. We highly appreciate all input from the
 community, be it bug reports or code contributions.
 
 Source code, issue tracking, discussion, and continuous integration appear on
-our `GitHub page <https://github.com/VarIr/deepnog>`_.
+our `GitHub page <https://github.com/univieCUBE/deepnog>`_.
 
 
 `What's new <changelog.html>`_


### PR DESCRIPTION
Update several links and mentions from gh:VarIr to gh:univieCUBE,
incl. CI badges and docs.