### PR TITLE
FIX use correct Python version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
 before_install:
   - bash build_tools/install-conda.sh
   - source "$HOME/miniconda/etc/profile.d/conda.sh"
+  - export PATH="${MINICONDA_DIR}/bin:$PATH"
   - conda activate test
   - hash -r
   - bash build_tools/install-pip.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,14 +32,13 @@ env:
   - PYTHONIOENCODING=UTF8
 
 before_install:
-  - export PATH="${MINICONDA_DIR}/bin:$PATH"
   - bash build_tools/install-conda.sh
+  - source "$HOME/miniconda/etc/profile.d/conda.sh"
+  - conda activate test
   - hash -r
-  - python -c "import sys; print(sys.version)"
   - bash build_tools/install-pip.sh
 
 install:
-  - python -c "import sys; print(sys.version)"
   - python setup.py build
   - python setup.py install
 
@@ -47,7 +46,6 @@ before_script:
   - flake8
 
 script:
-  - python -c "import sys; print(sys.version)"
   - pytest --cov=deepnog
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,13 @@ jobs:
     - name: Python 3.7 on MacOS X (xcode 10.3)
       os: osx
       language: shell
-      osx_image: xcode10.3  # Python 3.7
-    - name: Python 3.7 on MacOS X (xcode 11.3)
+      osx_image: xcode10.3
+      python: '3.7'
+    - name: Python 3.8 on MacOS X (xcode 11.3)
       os: osx
       language: shell
-      osx_image: xcode11.3  # Python 3.7.5
+      osx_image: xcode11.3
+      python: '3.8'
 
 env:
   global:

--- a/build_tools/install-conda.sh
+++ b/build_tools/install-conda.sh
@@ -28,9 +28,3 @@ fi
 if [[ ! -e "${MINICONDADIR}/envs/test/bin/python${TRAVIS_PYTHON_VERSION}" ]]; then
     conda create --yes -n test python="$TRAVIS_PYTHON_VERSION"
 fi
-
-# Finally load test environment to make sure we're using the specified Python version
-conda init bash
-source "$HOME/miniconda/etc/profile.d/conda.sh"
-conda activate test
-python -c "import sys; print(sys.version)"

--- a/build_tools/install-conda.sh
+++ b/build_tools/install-conda.sh
@@ -26,5 +26,5 @@ fi
 
 # Is the specified Python version available? If not, install it.
 if [[ ! -e "${MINICONDADIR}/envs/test/bin/python${TRAVIS_PYTHON_VERSION}" ]]; then
-    conda create --yes -n test python="$TRAVIS_PYTHON_VERSION"
+    "$MINICONDA_DIR/bin/conda" create --yes -n test python="$TRAVIS_PYTHON_VERSION"
 fi


### PR DESCRIPTION
Travis w/ miniconda currently is not configured to use $TRAVIS_PYTHON_VERSION,
which it should be. Otherwise it always uses the default version.