### PR TITLE
FIX Unrequired module imports (LGTM)

### DIFF
--- a/deepnog/__init__.py
+++ b/deepnog/__init__.py
@@ -11,15 +11,6 @@ usage of the tool, the reader is referred to the documentation as well as
 deepnog.py.
 
 """
-from . import (client,
-               dataset,
-               inference,
-               io,
-               models,
-               sync,
-               utils,
-               )
-
 # PEP0440 compatible formatted version, see:
 # https://www.python.org/dev/peps/pep-0440/
 #

--- a/deepnog/models/__init__.py
+++ b/deepnog/models/__init__.py
@@ -4,7 +4,5 @@ Description:
     Network definitions (PyTorch modules)
 """
 
-from . import deepencoding
-
 __all__ = ['deepencoding',
            ]


### PR DESCRIPTION
Remove imports of modules in their package's `__init__.py`, as this is not necessary (due to LGTM alerts)