### PR TITLE
CLI changes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-# max-line-length = 120
+max-line-length = 100
 # extend-ignore   = E203  # ignore "whitespace before ':'"

--- a/deepnog/client.py
+++ b/deepnog/client.py
@@ -194,8 +194,8 @@ def start_prediction(args):
         if 0.0 <= args.confidence_threshold <= 1.0:
             threshold = float(args.confidence_threshold)
         else:
-            raise RuntimeError('Invalid confidence threshold specified '
-                               '({args.confidence_threshold}).')
+            raise RuntimeError(f'Invalid confidence threshold specified '
+                               f'({args.confidence_threshold}).')
     elif hasattr(model, 'threshold'):
         threshold = float(model.threshold)
         eprint(f'Applying confidence threshold from model: {threshold}')
@@ -204,7 +204,7 @@ def start_prediction(args):
 
     # Predict labels of given data
     if args.verbose >= 2:
-        eprint(f'Predicting protein families ...')
+        eprint('Predicting protein families ...')
         if args.verbose >= 3:
             eprint(f'Process {args.batch_size} sequences per iteration: ')
     preds, confs, ids, indices = predict(model, dataset, device,

--- a/deepnog/client.py
+++ b/deepnog/client.py
@@ -42,7 +42,8 @@ def get_parser():
     from . import __version__
     parser = argparse.ArgumentParser(
         usage='%(prog)s proteins.faa --out predictions.csv',
-        description='Predict orthologous groups from protein sequences with deep learning.'
+        description='Predict orthologous groups from protein sequences with deep learning.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     parser.add_argument('--version',
                         action='version',
@@ -60,8 +61,7 @@ def get_parser():
                         type=str,
                         default='fasta',
                         help=("File format of protein sequences. Must be "
-                              "supported by Biopythons Bio.SeqIO class "
-                              "(default: fasta)"))
+                              "supported by Biopythons Bio.SeqIO class."))
     parser.add_argument("-of", "--outformat",
                         default="csv",
                         choices=["csv", "tsv", "legacy"],
@@ -70,14 +70,13 @@ def get_parser():
                         type=str,
                         choices=['eggNOG5', ],
                         default='eggNOG5',
-                        help="Orthologous group/family database to use "
-                             "(default: eggNOG5)")
+                        help="Orthologous group/family database to use.")
     parser.add_argument("-t", "--tax",
                         type=int,
                         choices=[1, 2, ],
                         default=2,
                         help="Taxonomic level to use in specified database "
-                             "(default: 2 = bacteria)")
+                             "(1 = root, 2 = bacteria)")
     parser.add_argument("--verbose",
                         type=int,
                         default=3,
@@ -96,7 +95,7 @@ def get_parser():
                         choices=['auto', 'cpu', 'gpu', ],
                         help=("Define device for calculating protein sequence "
                               "classification. Auto chooses GPU if available, "
-                              "otherwise CPU (default: auto)"))
+                              "otherwise CPU."))
     parser.add_argument("-nw", "--num-workers",
                         type=int,
                         default=0,
@@ -106,12 +105,11 @@ def get_parser():
                               'data loading. '
                               'Note: Only use multi-process data loading if '
                               'you are calculating on a gpu '
-                              '(otherwise inefficient)! Default: 0'))
+                              '(otherwise inefficient)!'))
     parser.add_argument("-a", "--architecture",
                         default='deepencoding',
                         choices=['deepencoding', ],
-                        help="Network architecture to use for classification "
-                             "(default: deepencoding)")
+                        help="Network architecture to use for classification.")
     parser.add_argument("-w", "--weights",
                         metavar='FILE',
                         help="Custom weights file path (optional)")

--- a/deepnog/io.py
+++ b/deepnog/io.py
@@ -50,7 +50,7 @@ def create_df(class_labels, preds, confs, ids, indices, threshold=None,
     indices : list[int]
         Stores the unique indices of sequences mapping to their position
         in the file
-    threshold : int
+    threshold : float
         If given, prediction labels and confidences are set to '' if
         confidence in prediction is not at least threshold.
     verbose : int

--- a/deepnog/tests/test_cli.py
+++ b/deepnog/tests/test_cli.py
@@ -44,13 +44,14 @@ def test_cmd_line_invocation(tax):
                                             out='out.mock.2',
                                             file=test_file,
                                             fformat='fasta',
+                                            outformat='csv',
                                             database='eggNOG5',
                                             verbose=3,
                                             device='auto',
                                             num_workers=0,
+                                            confidence_threshold=None,
                                             architecture='deepencoding',
                                             weights=None,
-                                            tab=None,
                                             batch_size=1,
                                             ))
 def test_main_and_argparsing(mock_args):

--- a/deepnog/utils.py
+++ b/deepnog/utils.py
@@ -16,6 +16,7 @@ import torch
 
 __all__ = ['EXTENDED_IUPAC_PROTEIN_ALPHABET',
            'set_device',
+           'eprint',
            'SeqIO',
            ]
 

--- a/deepnog/utils.py
+++ b/deepnog/utils.py
@@ -8,6 +8,7 @@ Description:
      Various utility functions
 """
 # SPDX-License-Identifier: BSD-3-Clause
+import sys
 import warnings
 
 import torch
@@ -56,3 +57,7 @@ def set_device(device):
     else:
         raise ValueError(f'Unknown device "{device}". Try "auto".')
     return device
+
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)


### PR DESCRIPTION
- Per default, commas are used instead of semicolons as field separators in prediction file. The field separator is now settable via the option `-of`, `--outformat`:
  - defaults to commas, `csv`
  - `tsv` uses tabs, replaces the flag `--tab`
  - `legacy` uses semicolons
- Any "logging" is now done to stderr instead of stdout. 
- Per default, predictions are written to stdout. This enables the aesthetically pleasing invocation:
  ```
  deepnog input.fa > predictions.csv
  ```
  Setting the output file with `--out` remains supported. 
- The confidence threshold for predictions can now be supplied by command line argument `-c`, `--confidence-threshold` and overrides any saved threshold in the model.