### PR TITLE
MNT Exit (not raising) on requesting unavailable device

### DIFF
--- a/deepnog/client/tests/test_cli.py
+++ b/deepnog/client/tests/test_cli.py
@@ -209,8 +209,7 @@ def test_args_sanity_check():
 
     args_device = deepcopy(args)
     args_device.device = None
-    with pytest.raises(ValueError):
-        _start_prediction_or_training(args_device)
+    _assert_exits(_start_prediction_or_training, args_device)
 
     args_train = deepcopy(args)
     args_train.phase = 'train'

--- a/deepnog/utils/network.py
+++ b/deepnog/utils/network.py
@@ -56,6 +56,7 @@ def set_device(device: Union[str, torch.device]) -> torch.device:
         Object containing the device type to be used for prediction
         calculations.
     """
+    err_msg = None
     if isinstance(device, torch.device):
         pass
     elif device == 'auto':
@@ -66,14 +67,19 @@ def set_device(device: Union[str, torch.device]) -> torch.device:
         if cuda:
             device = torch.device('cuda')
         else:
-            raise RuntimeError('Device set to "gpu", but could not access '
-                               'any CUDA-enabled GPU. Please make sure that '
-                               'a GPU is available and CUDA is installed'
-                               'on this machine.')
+            err_msg = ('Device set to "gpu", but could not access '
+                       'any CUDA-enabled GPU. Please make sure that '
+                       'a GPU is available and CUDA is installed '
+                       'on this machine.')
     elif device == 'cpu':
         device = torch.device('cpu')
     else:
-        raise ValueError(f'Unknown device "{device}". Try "auto".')
+        err_msg = f'Unknown device "{device}". Try "auto".'
+    if err_msg is not None:
+        logger = get_logger(__name__, verbose=0)
+        logger.error(f'Unknown device "{device}". Try "auto".')
+        import sys
+        sys.exit(1)
     return device
 
 

--- a/deepnog/utils/tests/test_utils.py
+++ b/deepnog/utils/tests/test_utils.py
@@ -16,11 +16,20 @@ TESTS = DEEPNOG_ROOT/"tests"
 WEIGHTS_PATH = TESTS/"parameters/test_deepencoding.pthsmall"
 
 
-def test_set_device():
+def _assert_exits(func, arguments):
+    with pytest.raises(SystemExit) as e:
+        func(arguments)
+    assert e.type == SystemExit
+    assert e.value.code == 1
+
+
+def test_set_device(caplog):
     device = 'tpu'
-    msg = f'Unknown device "{device}". Try "auto".'
-    with pytest.raises(ValueError, match=msg):
-        set_device(device)
+    with caplog.at_level(logging.ERROR):
+        _assert_exits(set_device, device)
+    # FIXME. Currently only the exit status is tested, not the message.
+    # msg = f'Unknown device "{device}". Try "auto".'
+    # assert msg in caplog.text
 
 
 def test_auto_device():
@@ -41,11 +50,13 @@ def test_gpu_device_available():
 
 
 @pytest.mark.skipif(GPU_AVAILABLE, reason='GPU is available')
-def test_gpu_device_unavailable():
+def test_gpu_device_unavailable(caplog):
     device = 'gpu'
-    msg = 'could not access any CUDA-enabled GPU'
-    with pytest.raises(RuntimeError, match=msg):
-        set_device(device)
+    with caplog.at_level(logging.ERROR):
+        _assert_exits(set_device, device)
+    # FIXME. Currently only the exit status is tested, not the message.
+    # msg = 'could not access any CUDA-enabled GPU'
+    # assert msg in caplog.text
 
 
 @pytest.mark.xfail(reason=("BUG: pytest logging capture does not work. "


### PR DESCRIPTION
Requesting an unavailable device (i.e. anything but 'cpu', 'auto', 'gpu', or 'gpu' when there is none) currently raises an error.
This PR makes deepnog instead log on logging.ERROR level and exit with error code 1.
Similar changes have previously been applied to the main client.

@LokiLuciferase Do you have any idea what's wrong with the pytest caplog tests? They should capture the logs, but don't. I only test for the exit code, therefore, but not for the correct message to the user.