### PR TITLE
BLD fix Travis MacOS Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,6 @@ jobs:
       dist: bionic
       language: python
       python: '3.8'
-    - name: Python 3.9 on Ubuntu Linux 18.04
-      os: linux
-      dist: bionic
-      language: python
-      python: '3.9'
     # See https://blog.travis-ci.com/2019-08-07-extensive-python-testing-on-travis-ci
     # for macos config peculiarities.
     - name: Python 3.7 on MacOS X (xcode 10.3)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ jobs:
       dist: bionic
       language: python
       python: '3.8'
+    - name: Python 3.9 on Ubuntu Linux 18.04
+      os: linux
+      dist: bionic
+      language: python
+      python: '3.9'
     # See https://blog.travis-ci.com/2019-08-07-extensive-python-testing-on-travis-ci
     # for macos config peculiarities.
     - name: Python 3.7 on MacOS X (xcode 10.3)
@@ -19,11 +24,13 @@ jobs:
       language: shell
       osx_image: xcode10.3
       python: '3.7'
+      env: TRAVIS_PYTHON_VERSION=3.7
     - name: Python 3.8 on MacOS X (xcode 11.3)
       os: osx
       language: shell
       osx_image: xcode11.3
       python: '3.8'
+      env: TRAVIS_PYTHON_VERSION=3.8
 
 env:
   global:

--- a/build_tools/install-conda.sh
+++ b/build_tools/install-conda.sh
@@ -8,20 +8,23 @@ if [[ -d "$MINICONDA_DIR" ]] && [[ -e "$MINICONDA_DIR/bin/conda" ]]; then
 else # if it does not exist, we need to install miniconda
     rm -rf "$MINICONDA_DIR" # remove the directory in case we have an empty cached directory
 
+    echo "Downloading miniconda..."
     if [[ "$TRAVIS_OS_NAME" == 'linux' ]]; then
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     elif [[ "$TRAVIS_OS_NAME" == 'osx' ]]; then
         wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
     fi
 
+    echo "Installing miniconda..."
     bash miniconda.sh -b -p "$MINICONDA_DIR"
     chown -R "$USER" "$MINICONDA_DIR"
     source "$HOME/miniconda/etc/profile.d/conda.sh"
     hash -r
     conda config --set always_yes yes --set changeps1 no
+    echo "Updating conda..."
     conda update -q conda
     conda info -a # for debugging
-    echo "$TRAVIS_PYTHON_VERSION"
+    echo "TRAVIS_PYTHON_VERSION=$TRAVIS_PYTHON_VERSION"
 fi
 
 # Is the specified Python version available? If not, install it.


### PR DESCRIPTION
MacOS builds on Travis fail due to erroneously set Python versions, which select 3.9, for which scikit-learn compilation fails.
This ensures the correct Python version is used on thsee builds.