### PR TITLE
MNT CI builds for Python 3.9

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,9 +15,9 @@ environment:
     - PYTHON: "C:\\Python38-x64"
       PYTHON_VERSION: "3.8.x"
       PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Python39-x64"
-      PYTHON_VERSION: "3.9.x"
-      PYTHON_ARCH: "64"
+    - PYTHON: C:\Python39
+      ARCHITECTURE: x86
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,12 @@ environment:
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7.x" # currently 3.7.?
       PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python39-x64"
+      PYTHON_VERSION: "3.9.x"
+      PYTHON_ARCH: "64"
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.
@@ -67,7 +73,6 @@ after_test:
   # If tests are successful, create binary packages for the project.
   - "python setup.py bdist_wheel"
   - "python setup.py bdist_wininst"
-  - "python setup.py bdist_msi"
   - ps: "ls dist"
 
 artifacts:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -15,9 +15,6 @@ environment:
     - PYTHON: "C:\\Python38-x64"
       PYTHON_VERSION: "3.8.x"
       PYTHON_ARCH: "64"
-    - PYTHON: C:\Python39
-      ARCHITECTURE: x86
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ jobs:
       dist: bionic
       language: python
       python: '3.8'
+    - name: Python 3.9 on Ubuntu Linux 20.04
+      os: linux
+      dist: focal
+      language: python
+      python: '3.9'
     # See https://blog.travis-ci.com/2019-08-07-extensive-python-testing-on-travis-ci
     # for macos config peculiarities.
     - name: Python 3.7 on MacOS X (xcode 10.3)

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## [Next release]
-...
+
+- CI: Linux/Travis builds with Python 3.9 (on Ubuntu 20.04 LTS/Focal)
+- CI: Windows/AppVeyor builds with Python 3.8, 3.9
 
 ## [1.2.2] - 2020-12-10
 


### PR DESCRIPTION
Add some builds to Travis and AppVeyor using Python 3.9