### PR TITLE
CI: Github Actions for Linux and MacOS builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,26 +17,25 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python: [3.7, 3.8, 3.9]
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
 
       - name: DEBUG workflow
         run: |
-          echo ${{ env.pythonLocation }}
-          echo ${{ matrix.python-version }}
+          echo ${{ matrix.python }}
 
       - name: Cache pip
         uses: actions/cache@v2
@@ -72,6 +71,7 @@ jobs:
 
       - name: Lint with flake8
         run: |
+          pip install flake8
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
@@ -79,6 +79,7 @@ jobs:
   
       - name: Test with pytest
         run: |
+          pip install pytest pytest-cov coverage codecov
           pytest deepnog/utils/tests/test_imports.py --hide-torch --cov
           pytest --cov=deepnog --cov-append
   

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,11 +17,9 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
-    # The type of runner that the job will run on
-    # runs-on: ubuntu-latest
     strategy:
       matrix:
-        runs-on: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]  # instead of runs-on
         python: [3.7, 3.8]
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+env:
+  MINICONDA_DIR: "$HOME/miniconda"
+  TRAVIS_OS_NAME: "linux"  # TODO remove
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -28,12 +32,49 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
+      # Cache the complete Python environment (esp. for large pkgs like PyTorch)
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.pythonLocation }}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/dev.txt}}
+
+      # Cache the models
+      - uses: actions/cache@v2
+        with:
+          path: $HOME/deepnog_data
+          key: ${{ hashFiles('config/deepnog_config.yml') }}
+
+      - name: DEBUG workflow
+        run: pwd
+
+      - name: Install dependencies
         run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+          python -m pip install --upgrade pip
+          pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
+  
+      - name: Install deepnog
+        run: python -m pip install -e .
+
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=100 --statistics
+  
+      - name: Test with pytest
+        run: |
+          pytest deepnog/utils/tests/test_imports.py --hide-torch --cov
+          pytest --cov=deepnog --cov-append
+  
+      - name: Coverage report
+        run: codecov
+
+
+
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]  # instead of runs-on

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.7, 3.8, 3.9]
+        python: [3.7, 3.8]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -35,13 +35,14 @@ jobs:
 
       - name: DEBUG workflow
         run: |
+          echo ${{ runner.os }}
           echo ${{ matrix.python }}
 
       - name: Cache pip
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/dev.txt') }}
+          key: ${{ runner.os }}-${{ matrix.python }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/dev.txt') }}
 
       # Cache the complete Python environment (esp. for large pkgs like PyTorch)
       #- name: Cache Python
@@ -56,9 +57,6 @@ jobs:
         with:
           path: $HOME/deepnog_data
           key: ${{ hashFiles('deepnog/config/deepnog_config.yml') }}
-
-      - name: DEBUG workflow
-        run: pwd
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade pip setuptools
           python3 -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
   
       - name: Install deepnog

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: DEBUG workflow
-        run: echo ${{ env.pythonLocation }}
+        run: |
+          echo ${{ env.pythonLocation }}
+          echo ${{ matrix.python-version }}
 
       - name: Cache pip
         uses: actions/cache@v2
@@ -54,7 +56,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: $HOME/deepnog_data
-          key: ${{ hashFiles('config/deepnog_config.yml') }}
+          key: ${{ hashFiles('deepnog/config/deepnog_config.yml') }}
 
       - name: DEBUG workflow
         run: pwd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          export PATH=${PATH}:"/home/runner/.local/bin"
           python3 -m pip install --upgrade pip setuptools
           python3 -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
   

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,12 +36,18 @@ jobs:
       - name: DEBUG workflow
         run: echo ${{ env.pythonLocation }}
 
-      # Cache the complete Python environment (esp. for large pkgs like PyTorch)
-      - name: Cache Python
+      - name: Cache pip
         uses: actions/cache@v2
         with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/dev.txt') }}
+          path: ~/.cache/pip
+          key: ${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/dev.txt') }}
+
+      # Cache the complete Python environment (esp. for large pkgs like PyTorch)
+      #- name: Cache Python
+      #  uses: actions/cache@v2
+      #  with:
+      #    path: ${{ env.pythonLocation }}
+      #    key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/dev.txt') }}
 
       # Cache the models
       - name: Cache DeepNOG models

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,10 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
     strategy:
       matrix:
+        runs-on: [ubuntu-latest, macos-latest]
         python: [3.7, 3.8]
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         python: [3.7, 3.8, 3.9]
     # The type of runner that the job will run on
-    runs-on: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,10 +13,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-env:
-  MINICONDA_DIR: "$HOME/miniconda"
-  TRAVIS_OS_NAME: "linux"  # TODO remove
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -37,14 +33,19 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: DEBUG workflow
+        run: echo ${{ env.pythonLocation }}
+
       # Cache the complete Python environment (esp. for large pkgs like PyTorch)
-      - uses: actions/cache@v2
+      - name: Cache Python
+        uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/dev.txt') }}
 
       # Cache the models
-      - uses: actions/cache@v2
+      - name: Cache DeepNOG models
+        uses: actions/cache@v2
         with:
           path: $HOME/deepnog_data
           key: ${{ hashFiles('config/deepnog_config.yml') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+# This is a basic workflow to help you get started with Actions
+
+name: deepnog CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    strategy:
+      matrix:
+        python: [3.7, 3.8, 3.9]
+    # The type of runner that the job will run on
+    runs-on: [ubuntu-latest, macos-latest, windows-latest]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: echo Hello, world!
+
+      # Runs a set of commands using the runners shell
+      - name: Run a multi-line script
+        run: |
+          echo Add other actions to build,
+          echo test, and deploy your project.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,11 +63,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
+          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade --upgrade-strategy eager -r requirements/dev.txt
   
       - name: Install deepnog
-        run: python -m pip install -e .
+        run: python3 -m pip install -e .
 
       - name: Lint with flake8
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/dev.txt}}
+          key: ${{ env.pythonLocation }}-${{ hashFiles('setup.py') }}-${{ hashFiles('requirements/dev.txt') }}
 
       # Cache the models
       - uses: actions/cache@v2
@@ -74,7 +74,3 @@ jobs:
   
       - name: Coverage report
         run: codecov
-
-
-
-


### PR DESCRIPTION
With Travis CI limiting build time dramatically, it is likely time to say goodbye to them.
Github now comes with Actions that provide CI right here.
This is an attempt to enable Actions for
- [x] Linux
- [x] MacOS
- [ ] Windows

with this order of importance. AppVeyor still works well for Windows builds up to Python 3.8