### PR TITLE
MNT enable CI for Python 3.9 on Linux and macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]  # instead of runs-on
-        python: [3.7, 3.8]
+        python: [3.7, 3.8, 3.9]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,9 +3,9 @@
 ## [Next release]
 ...
 
-### Changed in 1.2.3
+### New changes
 - CI with Github Actions (Linux, macOS)
-
+- CI: Python 3.9 on Linux, macOS
 
 ## [1.2.2] - 2020-12-10
 


### PR DESCRIPTION
Add 3.9 to Actions build matrix