### PR TITLE
FIX Pandas 1.2.0 related test failure

### DIFF
--- a/deepnog/data/dataset.py
+++ b/deepnog/data/dataset.py
@@ -531,7 +531,7 @@ class ProteinDataset(Dataset):
                                           compression='infer',
                                           dtype=str,
                                           )
-            except ValueError:
+            except (ValueError, TypeError):
                 pass
             if not isinstance(self.labels, pd.DataFrame):
                 raise ValueError('Invalid labels, must be .csv file or DataFrame')


### PR DESCRIPTION
Changes in `pandas=1.2.0` break a test case.
This is fixed here.