### PR TITLE
CI Temporarily remove Python 3.9 from github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,16 +58,6 @@ jobs:
           path: $HOME/deepnog_data
           key: ${{ hashFiles('deepnog/config/deepnog_config.yml') }}
 
-      # No standard scikit-learn wheels are currently available for Python 3.9
-      # Install pre release, instead of compiling from source.
-      # TODO delete when 0.24 with Python 3.9 support comes out.
-      - name: Install scikit-learn pre 0.24 for Python 3.9
-        if: ${{ matrix.python == '3.9' }}
-        run: |
-          export PATH=${PATH}:"/home/runner/.local/bin"
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --pre -U scikit-learn
-
       - name: Install dependencies
         run: |
           export PATH=${PATH}:"/home/runner/.local/bin"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]  # instead of runs-on
-        python: [3.7, 3.8, 3.9]
+        python: [3.7, 3.8]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
scikit-learn pre 0.24 was required on Python 3.9 (Github CI), but stable is available now.