### PR TITLE
Fix dropout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,16 +58,6 @@ jobs:
           path: $HOME/deepnog_data
           key: ${{ hashFiles('deepnog/config/deepnog_config.yml') }}
 
-      # No standard scikit-learn wheels are currently available for Python 3.9
-      # Install pre release, instead of compiling from source.
-      # TODO delete when 0.24 with Python 3.9 support comes out.
-      - name: Install scikit-learn pre 0.24 for Python 3.9
-        if: ${{ matrix.python == '3.9' }}
-        run: |
-          export PATH=${PATH}:"/home/runner/.local/bin"
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --pre -U scikit-learn
-
       - name: Install dependencies
         run: |
           export PATH=${PATH}:"/home/runner/.local/bin"

--- a/deepnog/client/tests/test_cli.py
+++ b/deepnog/client/tests/test_cli.py
@@ -253,7 +253,7 @@ def test_training_cmd_line_invocation():
             for k in ['phase', 'epoch', 'accuracy', 'loss']:
                 assert k in df.columns, f'Column {k} missing in output csv file'
             np.testing.assert_almost_equal(df.accuracy.iloc[-1], 1.0, decimal=3)
-            np.testing.assert_almost_equal(df.loss.iloc[-1], 0.07, decimal=3)
+            assert df.loss.iloc[-1] < 0.1, "Surprisingly high loss"
             assert df.phase.iloc[-2] == 'train', 'Second last phase was not "train".'
             assert df.phase.iloc[-1] == 'val', 'Last phase was not "val".'
             # Repeat twice: training & validation data

--- a/deepnog/models/deepnog.py
+++ b/deepnog/models/deepnog.py
@@ -182,7 +182,8 @@ class DeepNOG(nn.Module):
         x = torch.cat(max_pool_layer, dim=1)
         x = x.view(-1, x.shape[1])
 
-        # Classification layer
+        # Regularization and classification
+        x = self.dropout1(x)
         x = self.classification1(x)
 
         # NOTE: v1.2.0 removed the softmax here. Must now be performed in


### PR DESCRIPTION
Use dropout when training DeepNOG models. Fixes #44 
(Note to users: this does not affect any models created by our team, nor does it affect inference. This does affect, however, custom models trained by `deepnog` users).