### PR TITLE
Fix some warnings

### DIFF
--- a/deepnog/data/dataset.py
+++ b/deepnog/data/dataset.py
@@ -99,7 +99,7 @@ def collate_sequences(batch: Union[List[sequence_tuple], sequence_tuple],
             max_len = sequence_len
 
     # Collate the sequences
-    sequences = np.zeros((n_data, max_len,), dtype=np.int)
+    sequences = np.zeros((n_data, max_len,), dtype=np.int32)
     for i, seq in enumerate(batch):
         sequence = np.array(seq.encoded)
         # If selected, choose randomly, where to insert zeros
@@ -123,7 +123,7 @@ def collate_sequences(batch: Union[List[sequence_tuple], sequence_tuple],
 
     # Collate the labels
     try:
-        labels = np.array([b.label for b in batch], dtype=np.int)
+        labels = np.array([b.label for b in batch], dtype=np.int32)
         labels = default_collate(labels)
     except (AttributeError, TypeError):
         labels = None

--- a/deepnog/learning/tests/test_training.py
+++ b/deepnog/learning/tests/test_training.py
@@ -73,5 +73,3 @@ def test_shuffled_training(batch_size, num_workers):
         assert x.shape == (2, 30)
     np.testing.assert_equal(results.y_train_true.sum(), Y_TRUE.sum())  # order should be different
     np.testing.assert_equal(results.y_val_pred.sum(), Y_TRUE.sum())
-
-


### PR DESCRIPTION
Fix np.int usage warning, and flake8 warnings about superfluous lines at EOF.