### PR TITLE
FIX bioconda installs pytorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ instead.
 
 ``deepnog`` can also be installed from bioconda like this:
 ``` bash
-conda config --add channels pytorch
-conda install pytorch deepnog
+conda install deepnog
 ```
 
 ## Usage

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,7 +4,8 @@
 ...
 
 ### Fixes in 1.2.4
-- Bioconda automatically installs PyTorch ([see deepnog/#XX](TODO add link) and
+- Bioconda automatically installs PyTorch
+  ([see deepnog/#52](https://github.com/univieCUBE/deepnog/pull/52) and
   [bioconda/#27112](https://github.com/bioconda/bioconda-recipes/pull/27112))
 
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -3,6 +3,10 @@
 ## [Next release]
 ...
 
+### Fixes in 1.2.4
+- Bioconda automatically installs PyTorch ([see deepnog/#XX](TODO add link) and
+  [bioconda/#27112](https://github.com/bioconda/bioconda-recipes/pull/27112))
+
 
 ## [1.2.3] - 2021-02-09
 

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -18,13 +18,16 @@ We currently don't provide detailed instructions for Windows.
 Alternative: Installation from bioconda
 =======================================
 
-Alternatively, ``deepnog`` can be installed from bioconda like this:
+Alternatively, ``deepnog`` can be installed from bioconda
+with channel setup as described in the `bioconda docs`_ like this:
 
 .. code-block:: bash
 
-    # With channel setup as described in the `bioconda docs`_
-    conda config --add channels pytorch
-    conda install pytorch deepnog
+    conda install deepnog
+
+Note: Previously, bioconda required installing PyTorch from Facebook's pytorch
+channel manually.
+Since PyTorch is now available on conda-forge, this is not necessary anymore.
 
 .. _`bioconda docs`: https://bioconda.github.io/user/install.html#install-conda>
 
@@ -32,8 +35,10 @@ Dependencies and model files
 ============================
 
 All package dependencies of ``deepnog`` are automatically installed
-by ``pip``. We also require model files (= networks parameters/weights),
-which are too large for GitHub/PyPI. These are hosted on separate servers,
+by ``pip`` or ``conda``.
+We also require model files (= networks parameters/weights),
+which are too large for GitHub/PyPI/bioconda.
+Models are hosted on separate servers,
 and downloaded automatically by ``deepnog``, when required. By default,
 models are cached in `$HOME/deepnog_data/`.
 


### PR DESCRIPTION
`bioconda install deepnog` now installs deepnog alongside all its requirements, including `pytorch`.

This was previously not possible, because the pytorch package was not available from standard channels, but only from Facebook's pytorch channel. Bioconda had no way to configure additional channels.

Now pytorch is available from conda-forge, and we can include the requirement in the bioconda recipe. This also allows us to actually test deepnog in the conda recipe.

For the changed recipe, see https://github.com/bioconda/bioconda-recipes/pull/27112. Here we just update docs to reflect this change.