### PR TITLE
Update example.rst

### DIFF
--- a/doc/getting_started/example.rst
+++ b/doc/getting_started/example.rst
@@ -122,6 +122,5 @@ API Example Usage
        confs=confs,
        ids=ids,
        indices=indices,
-       threshold=CONF_THRESH,
-       verbose=3
+       threshold=CONF_THRESH
    )


### PR DESCRIPTION
create_df doesn't have a verbose parameter.